### PR TITLE
README: Use the canonical website address

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ DUMPER.JS 1.0
 
 Yet another tiny vanilla json dump'er for the browser
 
-https://nikopol.github.com/dumper.js/
+https://nikopol.github.io/dumper.js/
 
 **usages**
 


### PR DESCRIPTION
If you try to access the `.com` version you get redirected to the `.io` one anyway :beer: 
